### PR TITLE
add .env to .gitignore and create env_exemple for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.env
 dist
 dist-ssr
 *.local

--- a/env_exemple
+++ b/env_exemple
@@ -1,0 +1,3 @@
+BING_API_KEY="put api key"
+
+AI_CHATBOT_KEY="put api key"


### PR DESCRIPTION
This pull request includes the addition of environment variables to the `env_exemple` file. The new variables are placeholders for API keys required for Bing and an AI chatbot.

* [`env_exemple`](diffhunk://#diff-a29152d77925f21adef071da0c068d2c637b548c79020734b0edd209258cd129R1-R3): Added `BING_API_KEY` and `AI_CHATBOT_KEY` placeholders for API keys.